### PR TITLE
2nd Add Attachments button

### DIFF
--- a/assets/js/wpba-media-handler-new.js
+++ b/assets/js/wpba-media-handler-new.js
@@ -10,7 +10,7 @@ jQuery(function($){
 		* Attach Image
 		*/
 		// Uploading files
-		$('#wpba_attachments_button, #wpba_form_attachments_button').on('click', function( event ){
+		$('#wpba_attachments_button, #wpba_attachments_button2, #wpba_form_attachments_button').on('click', function( event ){
 			event.preventDefault();
 			var that = $(this);
 			// If the media frame already exists, reopen it.
@@ -43,6 +43,7 @@ jQuery(function($){
 						$( "#wpba_image_sortable" ).append( resp.image );
 						wpba.updateSortOrder($( "#wpba_image_sortable" ));
 						wpba.resetClickHandlers();
+						$('#wpba_attachments_button2').removeClass('hide');
 					}
 
 				});
@@ -52,5 +53,9 @@ jQuery(function($){
 			file_frame.open();
 		});
 
+		// Show the 2nd Add Attachments button if there are any attachments
+		if ($('.wpba-attachment-item').length) {
+			$('#wpba_attachments_button2').removeClass('hide');
+		}
 	}); // $(window).load()
 }(jQuery));

--- a/classes/class-wpba-meta-box.php
+++ b/classes/class-wpba-meta-box.php
@@ -141,6 +141,9 @@ class WPBA_Meta_Box extends WP_Better_Attachments
 			<div class="clear"></div>
 			<?php echo $this->output_post_attachments(); ?>
 			<div class="clear"></div>
+			<?php if ( floatval( $wp_version ) >= 3.5 ) { ?>
+				<a class="button wpba-attachments-button hide" id="wpba_attachments_button2" href="#"><span class="wpba-media-buttons-icon"></span> Add Attachments</a>
+			<?php } ?>
 		</div>
 		<?php
 		echo $this->edit_modal();


### PR DESCRIPTION
A second Add Attachments button is rendered with the metabox below the list of attachments. It is hidden until the first file is attached to the post. The purpose of the lower button is to improve usability when many files are attached to the same post, i.e. you don't have to scroll up to the top of the list to reveal the upper Add Attachments button if it is outside the viewport.