### PR TITLE
Further changes to allow additional fields/content in attachment items

### DIFF
--- a/classes/class-wp-better-attachments.php
+++ b/classes/class-wp-better-attachments.php
@@ -110,6 +110,7 @@ class WP_Better_Attachments
 	*/
 	public function init_hooks()
 	{
+		add_action( 'admin_init', array( &$this, 'register_admin_scripts' ) );
 		add_action( 'admin_enqueue_scripts', array( &$this, 'enqueue_admin_scripts' ) );
 		add_action( 'wp_enqueue_scripts', array( &$this, 'enqueue_scripts' ) );
 		add_action('media_buttons_context', array( &$this, 'add_form_button' ) );
@@ -317,6 +318,42 @@ class WP_Better_Attachments
 		return false;
 	} // current_post_type_disabled()
 
+	/**
+	 * resgisters Administrator Scripts and Styles
+	 *
+	 * @since 1.3.11
+	 *
+	 * @return void
+	 */
+	public function register_admin_scripts()
+	{
+		// WPBA Main Style File
+		wp_enqueue_style(
+			'wpba-admin-css',
+			plugins_url( 'assets/css/wpba-admin.css' , dirname( __FILE__ ) ),
+			null,
+			WPBA_VERSION,
+			'all'
+		);
+
+		// JS Dependencies
+		$deps = array(
+			'jquery',
+			'jquery-ui-core',
+			'jquery-ui-widget',
+			'jquery-ui-mouse',
+			'jquery-ui-sortable'
+		);
+
+		// WPBA Main Script File
+		wp_register_script(
+			'wpba-media-handler',
+			plugins_url( 'assets/js/wpba-media-handler-new.min.js' , dirname( __FILE__ ) ),
+			$deps,
+			WPBA_VERSION,
+			true
+		);
+	}
 
 
 	/**
@@ -338,35 +375,15 @@ class WP_Better_Attachments
 		$base = $current_screen->base;
 		if ( $base == 'edit' or $base == 'upload' or $base == 'post' OR $base == 'settings_page_wpba-settings' ) {
 			// WPBA Main Style File
-			wp_enqueue_style(
-				'wpba-admin-css',
-				plugins_url( 'assets/css/wpba-admin.css' , dirname( __FILE__ ) ),
-				null,
-				WPBA_VERSION,
-				'all'
-			);
+			wp_enqueue_style('wpba-admin-css');
 
-			// JS Dependencies
-			$deps = array(
-				'jquery',
-				'jquery-ui-core',
-				'jquery-ui-widget',
-				'jquery-ui-mouse',
-				'jquery-ui-sortable'
-			);
+
 
 			// Media Scripts
 			if ( !did_action( 'wp_enqueue_media' ) )
 				wp_enqueue_media();
 
-			// WPBA Main Script File
-			wp_register_script(
-				'wpba-media-handler',
-				plugins_url( 'assets/js/wpba-media-handler-new.min.js' , dirname( __FILE__ ) ),
-				$deps,
-				WPBA_VERSION,
-				true
-			);
+
 
 			wp_enqueue_script( 'wpba-media-handler' );
 		} // if()

--- a/classes/class-wpba-meta-box.php
+++ b/classes/class-wpba-meta-box.php
@@ -286,6 +286,7 @@ class WPBA_Meta_Box extends WP_Better_Attachments
 			$html .= '<li class="wpba-attachment-item ui-state-default" id="attachment_'.$attachment_id.'" data-id="'.$attachment_id.'">' . $nl;
 				$html .= '<div class="inner">' . $nl;
 				$html .= '<div class="wpba-drag-handle"><span>&nbsp;</span><span>&nbsp;</span><span>&nbsp;</span></div>' . $nl;
+				$html .= apply_filters('wpba_image_attachment_li_content_before', '', $attachment, $mime_type) . $nl;
 				$html .= '<div class="wpba-preview pull-left" data-id="'.$attachment_id.'">' . $nl;
 					$html .= $this->output_menu_id_title( $attachment, $mime_type );
 					$html .= $this->output_placeholder_image( $attachment, $mime_type );
@@ -295,6 +296,7 @@ class WPBA_Meta_Box extends WP_Better_Attachments
 					$html .= '<div>' . $this->output_caption_input( array( 'attachment' => $attachment) ) . '</div>'  . $nl;
 				$html .= '</div>' . $nl;
 				$html .= '<div class="clear"></div>' . $nl;
+				$html .= apply_filters('wpba_image_attachment_li_content_after', '', $attachment, $mime_type) . $nl;
 				$html .= '</div>' . $nl;
 			$html .= '</li>'  . $nl;
 		} // foreach();


### PR DESCRIPTION
I have added 3 filters (would they be better as actions ?) 
- wpba_image_attachment_li_content_before
- wpba_image_attachment_li_form_after
- wpba_image_attachment_li_content_after

that allow addition of content to attachment items.

Each are given html (blank string), attachments, post, and mime type

I have also registered wpba-admin-css to allow for cleaner overriding of wpba styles.